### PR TITLE
Add aihe Stray Animal Home domain

### DIFF
--- a/db.ngo.us
+++ b/db.ngo.us
@@ -33,6 +33,13 @@ _whois._tcp	3600	IN	SRV	0 0 43 whois.ngo.us.
 
 ; ========== BEGIN ORGANIZATIONS ==============
 
+; Aihe Stray Animal Home
+; Submitted by customer service team XERA <service@aihe.daemon.asia>
+aihe 86400 IN NS emerie.ns.cloudflare.com.
+aihe 86400 IN NS ignacio.ns.cloudflare.com.
+xera 86400 IN NS dave.ns.cloudflare.com.
+xera 86400 IN NS irena.ns.cloudflare.com.
+
 ; Lively Souls Foundation
 liveleak	86400	IN	NS	dns1.p08.nsone.net.
 liveleak	86400	IN	NS	dns2.p08.nsone.net.


### PR DESCRIPTION
### Intended Use of Domain:
The domains "aihe.ngo.us" and "xera.ngo.us" will be used for "aihe Stray Animal Home", a nonprofit organization based in Hong Kong. These domains will provide details about our mission, including rescuing stray animals, helping them recover, and finding permanent homes for them. The website will also serve as a hub for connecting with potential adopters and supporters.

### Organization Online Presence URLs for Verification:
https://aihe.daemon.asia/

### Proof of Domain Mention:
We plan to use "aihe.ngo.us" and "xera.ngo.us" as our main domains, and we have already posted about it in the welcome section of our website: https://aihe.daemon.asia/
![20241022003209](https://github.com/user-attachments/assets/139150cd-c6dc-44d3-bb49-2d84f8f94b0d)


### Agreement to Terms:
By submitting this pull request, I agree to the following:
- My organization is a non-commercial entity and is not affiliated with any government body.
- My organization operates legally and in good faith, according to the stated purpose.
- I have provided accurate and truthful information throughout this application.
- I agree to the terms outlined in the registry’s Terms of Service.

qingqing, on behalf of aihe Stray Animal Home, agree to the terms and conditions outlined above.