### PR TITLE
Add Freefall Softworks Archival Organization (FSARO) To Registry

### DIFF
--- a/db.ngo.us
+++ b/db.ngo.us
@@ -40,6 +40,13 @@ aihe 86400 IN NS ignacio.ns.cloudflare.com.
 xera 86400 IN NS dave.ns.cloudflare.com.
 xera 86400 IN NS irena.ns.cloudflare.com.
 
+; Freefall Softworks Archival Organization (FSARO)
+; Submitted by the FSARO development team <fsaro@proton.me>
+fsaro 86400 IN NS drake.ns.cloudflare.com.
+fsaro 86400 IN NS serenity.ns.cloudflare.com.
+fsao 86400 IN NS drake.ns.cloudflare.com.
+fsao 86400 IN NS serenity.ns.cloudflare.com.
+
 ; Lively Souls Foundation
 liveleak	86400	IN	NS	dns1.p08.nsone.net.
 liveleak	86400	IN	NS	dns2.p08.nsone.net.

--- a/db.ngo.us
+++ b/db.ngo.us
@@ -46,6 +46,8 @@ fsaro 86400 IN NS drake.ns.cloudflare.com.
 fsaro 86400 IN NS serenity.ns.cloudflare.com.
 fsao 86400 IN NS drake.ns.cloudflare.com.
 fsao 86400 IN NS serenity.ns.cloudflare.com.
+fsarorg 86400 IN NS drake.ns.cloudflare.com.
+fsarorg 86400 IN NS serenity.ns.cloudflare.com.
 
 ; Lively Souls Foundation
 liveleak	86400	IN	NS	dns1.p08.nsone.net.


### PR DESCRIPTION
Intended Use of Domain: 
The domain will be used to connect the website under a custom domain, as well as streamline communication by allowing users to contact us via a branded email, alongside other branded emails for the organization to use.

Organization Online Presence URLs for Verification:
Please note that we are fairly new - as such, we have social media pages, but they are new. Our GitHub and Discord has been around longer, however. We ask that you do excuse any traces of our old branding (FSDMC), and we assure you that we are working on a rebrand (which may already have taken place by the time this is read). If our social media is not verifiable, we ask that you please use our website/discord instead.

GitHub: https://github.com/FSARO (website repository at https://github.com/FSARO/fsaro.github.io)
X: https://x.com/FSARORG
Discord: https://fsaro.github.io/discord
Website: https://fsaro.github.io

Agreement to Terms
By submitting this pull request, I agree to the following:

My organization is a non-commercial entity that is not affiliated with any government body.
My organization operates legally and in good faith according to the stated purpose.
I have provided accurate and truthful information throughout this application.
Other terms outlined in the Registry's Terms of Service.

From the FSARO Development Team, thank you for reading our application!